### PR TITLE
Review policy: do not merge tag

### DIFF
--- a/review-policies/core-developers.yml
+++ b/review-policies/core-developers.yml
@@ -142,9 +142,9 @@ approval_rules:
       
     ignore_update_merges: true
 - name: do not merge
-  description: If the "DO NOT MERGE" tag is applied, merging is blocked
+  description: "If the 'review: do not merge' tag is applied, merging is blocked"
   requires:
     count: 1
     users: ["ghost"]  # We need a rule that cannot complete
   if:
-    has_labels: ["DO NOT MERGE"]
+    has_labels: ["review: do not merge"]


### PR DESCRIPTION
This adds a rule that won't ever complete (require a review from the ghost user, which cannot exist).
The rule is only applied if a "DO NOT MERGE" label is added to the PR.

The PR also adds @janine9vn to the event rule.