### PR TITLE
Tagger workflow

### DIFF
--- a/review-policies/core-developers.yml
+++ b/review-policies/core-developers.yml
@@ -141,9 +141,11 @@ approval_rules:
       
     ignore_update_merges: true
 - name: do not merge
-  description: "If the 'review: do not merge' tag is applied, merging is blocked"
+  description: "If the 'review: do not merge' or 'needs testing' tag is applied, merging is blocked"
   requires:
     count: 1
     users: ["ghost"]  # We need a rule that cannot complete
   if:
-    has_labels: ["review: do not merge"]
+    has_labels: 
+      - "review: do not merge"
+      - "needs testing"

--- a/workflows/auto_tagger_config.yaml
+++ b/workflows/auto_tagger_config.yaml
@@ -1,0 +1,2 @@
+needs testing:
+- "**/**"

--- a/workflows/auto_tagger_workflow.yaml
+++ b/workflows/auto_tagger_workflow.yaml
@@ -1,0 +1,16 @@
+name: "Pull request needs testing tagger"
+
+on:
+  workflow_call:
+    secrets:
+      token:
+        required: true
+
+jobs:
+  add_tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: ${{ secrets.token }}
+        configuration-path: "workflows/auto_tagger_config.yaml"


### PR DESCRIPTION
This workflow will automatically apply any labels, as defined in the auto_tagger_config.yaml config file. This runs on PR open, reopen and synchronize, which is triggered when a commit is pushed to the PR branch.

If the label doesn't exist in the repo, it will be created automatically.

This allows us to enforce the removal of a "needs testing" tag before any PRs are merged, as reminder for us that PRs should be tested by at least one person before merging.