### PR TITLE
Allow admins/event lead to speedrun event content changes

### DIFF
--- a/review-policies/core-developers.yml
+++ b/review-policies/core-developers.yml
@@ -4,13 +4,14 @@ policy:
     - and:
       - core dev
       - staff or contributor
+      - events
+    - events
     - tag speedrun
     - or:
       - site content (staff)
       - site content (admin)
   - devops
   - devops (manual)
-  - events
   - do not merge
 
   # Rules for disapproving


### PR DESCRIPTION
By moving events inside the first OR block, this allows PRs with only event content changes to be merged with just an admins/event lead approval.

However, by moving events inside that block, it would also mean that the coredev/staff AND block could also satisfy a event content PR approval. To mitigate this, I also added events into that block too, meaning that AND block would also require amdins/event lead approval to satisfy a PR, but would be skipped when paths do not match.