### PR TITLE
Add status_embed workflow

### DIFF
--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -1,0 +1,63 @@
+name: Status Embed
+
+on:
+  workflow_call:
+    inputs:
+      job_status:
+        required: true
+        type: string
+    secrets:
+      webhook_token:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  status_embed:
+    # We need to send a status embed whenever the workflow
+    # sequence we're running terminates. There are a number
+    # of situations in which that happens:
+    #
+    # 1. We reach the end of the Deploy workflow, without
+    #    it being skipped.
+    #
+    # 2. A `pull_request` triggered a Lint & Test workflow,
+    #    as the sequence always terminates with one run.
+    #
+    # 3. If any workflow ends in failure or was cancelled.
+    if: >-
+      (github.workflow == 'Deploy' && ${{ inputs.job_status }} != 'skipped') ||
+      github.event_name == 'pull_request' ||
+      ${{ inputs.job_status }} == 'failure' ||
+      ${{ inputs.job_status }} == 'cancelled'
+    name:  Send Status Embed to Discord
+    runs-on: ubuntu-latest
+
+    steps:
+      # Send an informational status embed to Discord instead of the
+      # standard embeds that Discord sends. This embed will contain
+      # more information and we can fine tune when we actually want
+      # to send an embed.
+      - name: GitHub Actions Status Embed for Discord
+        uses: SebastiaanZ/github-status-embed-for-discord@v0.2.1
+        with:
+          # Our GitHub Actions webhook
+          webhook_id: '784184528997842985'
+          webhook_token: ${{ secrets.webhook_token }}
+
+          # Workflow information
+          workflow_name: ${{ github.workflow }}
+          run_id: ${{ github.run_id }}
+          run_number: ${{ github.run_number }}
+          status: ${{ inputs.job_status }}
+          actor: ${{ github.actor }}
+          repository:  ${{ github.repository }}
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
+
+          pr_author_login: ${{ github.event.pull_request.user.login}}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_title: ${{ github.event.pull_request.title }}
+          pr_source: ${{ github.event.pull_request.head.label }}


### PR DESCRIPTION
As a continuation to [this PR](https://github.com/python-discord/bot/pull/2400), we now want all of our repositories that need the `status_embed` workflow to use a centralized reusable workflow.

We've decided to add it to this repo and have it referenced by all of our other repositories that need to trigger it upon linting, building, etc.

**NOTE**
the `GHA_WEBHOOK_TOKEN` secret needs to be part of this repository in order for it to be reusable all over. 