### PR TITLE
Add a workflow that blocks fixup commits

### DIFF
--- a/.github/workflows/block-fixup-commits.yaml
+++ b/.github/workflows/block-fixup-commits.yaml
@@ -1,0 +1,28 @@
+name: Block "fixup" commit merges
+
+on:
+  workflow_call:
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: ${{ github.event.pull_request.commits }} + 1
+
+    - name: Fetch the base branch
+      run:  git fetch origin ${{ github.event.pull_request.base.ref }}
+
+    - name: Look for the fixup prefix
+      id: search-for-fixup-prefix
+      run: |
+        commit_messages=$(git log origin/${{ github.event.pull_request.base.ref }}..$GITHUB_HEAD_REF --format=%B)
+
+        if echo "$commit_messages" | grep -q "^fixup"; then
+          echo "Please make sure to squash all commits that have the 'fixup' prefix in your commit messages."
+          exit 1
+        fi

--- a/.github/workflows/block-fixup-commits.yaml
+++ b/.github/workflows/block-fixup-commits.yaml
@@ -11,8 +11,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: ${{ github.event.pull_request.commits }} + 1
+        ref: ${{ github.event.pull_request.head.ref }} # To ensure we have an attached HEAD
+        fetch-depth: ${{ github.event.pull_request.commits }} + 1 # Ensure the fork point is checked out
 
     - name: Fetch the base branch
       run:  git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -21,8 +21,10 @@ jobs:
       id: search-for-fixup-prefix
       run: |
         commit_messages=$(git log origin/${{ github.event.pull_request.base.ref }}..$GITHUB_HEAD_REF --format=%B)
-
-        if echo "$commit_messages" | grep -q "^fixup"; then
-          echo "Please make sure to squash all commits that have the 'fixup' prefix in your commit messages."
-          exit 1
+        fixup_commits=$(echo "$commit_messages" | grep "^fixup")
+        if [ -n "$fixup_commits" ]; then
+            echo "Please make sure that all commits that have the 'fixup' prefix need to be squashed before merging."
+            echo "Commits with 'fixup' prefix:"
+            echo "$fixup_commits"
+            exit 1
         fi


### PR DESCRIPTION
We want to block all commits that are prefixed with `fixup` as these are intended to be squashed, and authors can sometimes to do so.

The following wokflow will be a reusable one that all our other repos can call.