### PR TITLE
Suppress grep errors in the fixup commit blocker workflow

### DIFF
--- a/.github/workflows/block-fixup-commits.yaml
+++ b/.github/workflows/block-fixup-commits.yaml
@@ -21,7 +21,7 @@ jobs:
       id: search-for-fixup-prefix
       run: |
         commit_messages=$(git log origin/${{ github.event.pull_request.base.ref }}..$GITHUB_HEAD_REF --format=%B)
-        fixup_commits=$(echo "$commit_messages" | grep "^fixup")
+        fixup_commits=$(echo "$commit_messages" | grep "^fixup" || true)
         if [ -n "$fixup_commits" ]; then
             echo "Please make sure that all commits that have the 'fixup' prefix need to be squashed before merging."
             echo "Commits with 'fixup' prefix:"


### PR DESCRIPTION
This is because when grep doesn't find a match it returns an exit code 1, which makes github think an error occured so the entire workflow stops