### PR TITLE
Use github cli to checkout to fork repo branches.

### DIFF
--- a/.github/workflows/block-fixup-commits.yaml
+++ b/.github/workflows/block-fixup-commits.yaml
@@ -8,19 +8,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
+    - name: Checkout base repo
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.ref }} # To ensure we have an attached HEAD
-        fetch-depth: ${{ github.event.pull_request.commits }} + 1 # Ensure the fork point is checked out
+        ref: ${{ github.event.pull_request.base.ref }}
 
-    - name: Fetch the base branch
-      run:  git fetch origin ${{ github.event.pull_request.base.ref }}
+    - name: Checkout to the pull request's branch
+      run: gh pr checkout ${{ github.event.pull_request.number }}
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Look for the fixup prefix
       id: search-for-fixup-prefix
       run: |
-        commit_messages=$(git log origin/${{ github.event.pull_request.base.ref }}..$GITHUB_HEAD_REF --format=%B)
+        commit_messages=$(git log origin/${{ github.event.pull_request.base.ref }}..HEAD --format=%B)
         fixup_commits=$(echo "$commit_messages" | grep "^fixup" || true)
         if [ -n "$fixup_commits" ]; then
             echo "Please make sure that all commits that have the 'fixup' prefix need to be squashed before merging."


### PR DESCRIPTION
The workflow that blocks fixup commits fails when a pull request is issued from a fork.
That is due to the fact that when using the `checkout` action, it defaults to the `base` repo and not the `fork`'s, which makes the `fork`'s branch unkown.

The solution we went with is to checkout to the `base` repo, and use `gh cli` to checkout to the `pull_request`'s HEAD.

The rest remains the same. 